### PR TITLE
[IoValue] Handle `signed/unsigned long long` (8 Bytes)

### DIFF
--- a/src/Model/IoValue.php
+++ b/src/Model/IoValue.php
@@ -26,6 +26,7 @@ class IoValue extends Model
             1 => 'C',
             2 => 'S',
             4 => 'L',
+            8 => 'Q',
             default => throw new IoValueLengthException(strlen($this->binary)),
         };
 
@@ -41,6 +42,7 @@ class IoValue extends Model
             1 => 'c',
             2 => 's',
             4 => 'l',
+            8 => 'q',
             default => throw new IoValueLengthException(strlen($this->binary)),
         };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | [Public Domain](https://github.com/uro/teltonika-fm-parser/blob/master/LICENSE.md)

This PR allows to decode `unsigned long long` (8 Bytes) like the `ICCID1` parameter.

I have not any example of `signed long long` yet.