### PR TITLE
[IoElement] Fix a "Warning: Undefined array key" when the property does not exist

### DIFF
--- a/src/Model/IoElement.php
+++ b/src/Model/IoElement.php
@@ -32,7 +32,7 @@ class IoElement extends Model
 
     public function getPropertyById(int $id): ?IoProperty
     {
-        return $this->properties[$id];
+        return $this->properties[$id] ?? null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | [Public Domain](https://github.com/uro/teltonika-fm-parser/blob/master/LICENSE.md)

Calling the method `IoElement::getPropertyById` with an ID not in the `IoElement` throws a warning  "Warning: Undefined array key" when the property is missing from the data.

This PR fixes this.
