### PR TITLE
[IoElement] Fix the error when it has no property

### DIFF
--- a/src/Model/IoElement.php
+++ b/src/Model/IoElement.php
@@ -9,7 +9,7 @@ class IoElement extends Model
     /**
      * @var IoProperty[]
      */
-    private array $properties;
+    private array $properties = [];
 
     public function __construct(private readonly int $eventId, private readonly int $numberOfElements)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | [Public Domain](https://github.com/uro/teltonika-fm-parser/blob/master/LICENSE.md)

Calling the method `IoElement::getProperties` throws an error  "$properties must not be accessed before initialization" when the device is configured to send no IOElement.

This PR fixes this.
