### PR TITLE
Bugfix/exception on getting property by

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
 FROM php:8.1-cli AS php-81-dev
 RUN apt-get update && apt-get install -y git zip
-COPY --from=composer:2.5 /usr/bin/composer /usr/local/bin/composer
+RUN pecl install pcov && docker-php-ext-enable pcov
+COPY --from=composer:2.7 /usr/bin/composer /usr/local/bin/composer
+RUN docker-php-ext-install bcmath
+
+FROM php:8.2-cli AS php-82-dev
+RUN apt-get update && apt-get install -y git zip
+RUN pecl install pcov && docker-php-ext-enable pcov
+COPY --from=composer:2.7 /usr/bin/composer /usr/local/bin/composer
+RUN docker-php-ext-install bcmath
+
+FROM php:8.3-cli AS php-83-dev
+RUN apt-get update && apt-get install -y git zip
+RUN pecl install pcov && docker-php-ext-enable pcov
+COPY --from=composer:2.7 /usr/bin/composer /usr/local/bin/composer
 RUN docker-php-ext-install bcmath

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,59 @@
 build:
 	docker build --target php-81-dev -t php-81-dev .
+	docker build --target php-82-dev -t php-82-dev .
+	docker build --target php-83-dev -t php-83-dev .
 
-ssh:
+ssh: ssh_83
+
+ssh_81:
 	docker run --rm -it -v $(PWD):/app -w /app php-81-dev bash
 
-composer_install:
+ssh_82:
+	docker run --rm -it -v $(PWD):/app -w /app php-82-dev bash
+
+ssh_83:
+	docker run --rm -it -v $(PWD):/app -w /app php-83-dev bash
+
+composer_install: composer_install_83
+
+composer_install_81:
 	docker run --rm -v $(PWD):/app -w /app php-81-dev composer install
 
-phpunit:
+composer_install_82:
+	docker run --rm -v $(PWD):/app -w /app php-82-dev composer install
+
+composer_install_83:
+	docker run --rm -v $(PWD):/app -w /app php-83-dev composer install
+
+phpunit: phpunit_83
+
+phpunit_81:
 	docker run --rm -v $(PWD):/app -w /app php-81-dev vendor/bin/phpunit
 
-phpstan:
+phpunit_82:
+	docker run --rm -v $(PWD):/app -w /app php-82-dev vendor/bin/phpunit
+
+phpunit_83:
+	docker run --rm -v $(PWD):/app -w /app php-83-dev vendor/bin/phpunit
+
+phpstan: phpunit_83
+
+phpstan_81:
 	docker run --rm -v $(PWD):/app -w /app php-81-dev vendor/bin/phpstan analyze
 
-phpcsfixer:
+phpstan_82:
+	docker run --rm -v $(PWD):/app -w /app php-82-dev vendor/bin/phpstan analyze
+
+phpstan_83:
+	docker run --rm -v $(PWD):/app -w /app php-83-dev vendor/bin/phpstan analyze
+
+phpcsfixer: phpcsfixer_83
+
+phpcsfixer_81:
 	docker run --rm -v $(PWD):/app -w /app php-81-dev vendor/bin/php-cs-fixer fix --dry-run --diff --verbose
+
+phpcsfixer_82:
+	docker run --rm -v $(PWD):/app -w /app php-82-dev vendor/bin/php-cs-fixer fix --dry-run --diff --verbose
+
+phpcsfixer_83:
+	docker run --rm -v $(PWD):/app -w /app php-83-dev vendor/bin/php-cs-fixer fix --dry-run --diff --verbose

--- a/src/Model/IoElement.php
+++ b/src/Model/IoElement.php
@@ -9,7 +9,7 @@ class IoElement extends Model
     /**
      * @var IoProperty[]
      */
-    private array $properties;
+    private array $properties = [];
 
     public function __construct(private readonly int $eventId, private readonly int $numberOfElements)
     {
@@ -30,9 +30,14 @@ class IoElement extends Model
         return $this->properties;
     }
 
+    public function hasPropertyById(int $id): bool
+    {
+        return array_key_exists($id, $this->properties);
+    }
+
     public function getPropertyById(int $id): ?IoProperty
     {
-        return $this->properties[$id];
+        return $this->hasPropertyById($id) ? $this->properties[$id] : null;
     }
 
     /**

--- a/tests/Unit/Model/IoElementTest.php
+++ b/tests/Unit/Model/IoElementTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Model;
 
 use PHPUnit\Framework\TestCase;
 use Uro\TeltonikaFmParser\Model\IoElement;
+use Uro\TeltonikaFmParser\Model\IoProperty;
+use Uro\TeltonikaFmParser\Model\IoValue;
 
 class IoElementTest extends TestCase
 {
@@ -27,5 +29,18 @@ class IoElementTest extends TestCase
         $numberOfElements = (new IoElement(0, 2))->getNumberOfElements();
 
         $this->assertEquals(2, $numberOfElements);
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_properties(): void
+    {
+        $properties = [new IoProperty(1, new IoValue(''))];
+
+        $ioElement = new IoElement(0, 2);
+        $ioElement->addProperties($properties);
+
+        $this->assertEqualsCanonicalizing($properties, $ioElement->getProperties());
     }
 }


### PR DESCRIPTION
IoElement model fixed to handle cases when trying to retrieve a property by ID, and the property does not exist in the properties array.

Solution:
Added the method hasPropertyById(int $id).

Additionally, updated the Makefile and Dockerfile to allow running tests on multiple PHP versions (8.1, 8.2, 8.3).